### PR TITLE
Add 'Good Standing Discount' Feature

### DIFF
--- a/chezbetty/datalayer.py
+++ b/chezbetty/datalayer.py
@@ -120,10 +120,13 @@ def purchase(user, account, items):
     assert(hasattr(user, "id"))
     assert(len(items) > 0)
 
+    # TODO: Parameterize
+    discount = Decimal(0.05) if user.balance > 20.0 else None
+
     e = event.Purchase(user)
     DBSession.add(e)
     DBSession.flush()
-    t = transaction.Purchase(e, account)
+    t = transaction.Purchase(e, account, discount)
     DBSession.add(t)
     DBSession.flush()
     amount = Decimal(0.0)
@@ -134,6 +137,8 @@ def purchase(user, account, items):
                                            item.price, item.wholesale)
         DBSession.add(pli)
         amount += line_amount
+    if discount:
+        amount = amount - (amount * discount)
     t.update_amount(amount)
     return t
 

--- a/chezbetty/migrations/migration_1.5.0-1.6.0.sql
+++ b/chezbetty/migrations/migration_1.5.0-1.6.0.sql
@@ -1,3 +1,5 @@
 ALTER TABLE pools ADD COLUMN credit_limit numeric NOT NULL default 20;
 ALTER TABLE pools_history ADD COLUMN credit_limit numeric NOT NULL default 20;
 ALTER TABLE box_items ADD COLUMN percentage numeric NOT NULL default 0;
+
+ALTER TABLE transactions ADD COLUMN discount NUMERIC;

--- a/chezbetty/models/transaction.py
+++ b/chezbetty/models/transaction.py
@@ -217,9 +217,12 @@ account.Account.total_purchases = __total_purchase_amount
 
 class Purchase(Transaction):
     __mapper_args__ = {'polymorphic_identity': 'purchase'}
-    def __init__(self, event, user):
+    discount = Column(Numeric)
+
+    def __init__(self, event, user, discount=None):
         chezbetty_v = account.get_virt_account("chezbetty")
         Transaction.__init__(self, event, user, chezbetty_v, None, None, Decimal(0.0))
+        self.discount = discount
 
 
 class Deposit(Transaction):

--- a/chezbetty/static/css/chezbetty.css
+++ b/chezbetty/static/css/chezbetty.css
@@ -132,9 +132,13 @@ h1 {
 .purchase-item {
 }
 
-#purchase-total {
+#purchase-total, #purchase-subtotal, #purchase-discount, #purchase-discount-percent {
 	text-align: right;
 	font-weight: bold;
+}
+
+#purchase-discount, #purchase-discount-percent {
+  color: red;
 }
 
 /* Items */

--- a/chezbetty/static/js/chezbetty.js
+++ b/chezbetty/static/js/chezbetty.js
@@ -158,5 +158,21 @@ function calculate_total () {
 		}
 	});
 
+	var discount_td = $("#purchase-discount");
+	if (typeof discount_td !== 'undefined') {
+		var discount_percent_td = $("#purchase-discount-percent");
+		var discount_percent_str = discount_percent_td.text().slice(1,-2);
+		var discount_percent = parseFloat(discount_percent_str) * .01;
+		var discount = total * discount_percent;
+
+		$("#purchase-subtotal").html(format_price(total));
+
+		// basic sanity check
+		if ((total - discount) > 0) {
+			total = total - discount;
+			discount_td.html('(' + format_price(discount) + ')');
+		}
+	}
+
 	$("#purchase-total").html(format_price(total));
 }

--- a/chezbetty/templates/admin/event.jinja2
+++ b/chezbetty/templates/admin/event.jinja2
@@ -39,6 +39,9 @@
       <dl class="dl-horizontal">
         <dt>Type</dt><dd>{{ t.type }}</dd>
         <dt>Amount</dt><dd>{{ t.amount|format_currency|safe }}</dd>
+        {% if t.discount %}
+        <dt>Discount</dt><dd>{{ ((t.amount / (1-t.discount)) - t.amount)|format_currency|safe }} ({{ '{:.2}'.format(t.discount*100) }}%)</dd>
+        {% endif %}
         <dt>From Account (Virt)</dt><dd>{{ t.fr_account_virt.name if t.fr_account_virt else "n/a" }}</dd>
         <dt>To Account (Virt)</dt><dd>{{ t.to_account_virt.name if t.to_account_virt else "n/a" }}</dd>
         <dt>From Account (Cash)</dt><dd>{{ t.fr_account_cash.name if t.fr_account_cash else "n/a" }}</dd>

--- a/chezbetty/templates/purchase.jinja2
+++ b/chezbetty/templates/purchase.jinja2
@@ -52,6 +52,17 @@
           </tbody>
 
           <tfoot>
+            {% if user.balance > 20 %} {# todo: parameterize this #}
+            <tr>
+              <td colspan="4"><b>{{ _('Subtotal') }}</b></td>
+              <td id="purchase-subtotal">$0.00</td>
+            </tr>
+            <tr>
+              <td colspan="2"><b>{{ _('Good Standing Discount') }}</b></td>
+              <td id="purchase-discount-percent" colspan="2">(5.0%)</td>
+              <td id="purchase-discount">($0.00)</td>
+            </tr>
+            {% endif %}
             <tr>
               <td colspan="4"><b>{{ _('Total') }}</b></td>
               <td id="purchase-total">$0.00</td>

--- a/chezbetty/templates/purchase_complete.jinja2
+++ b/chezbetty/templates/purchase_complete.jinja2
@@ -44,7 +44,7 @@
         </tr>
         <tr>
           <td><b>{{ _('Discounts') }}</b></td>
-          <td id="purchase-discount-percent" colspan="2">({{ '{:.2}'.format(order['discount']) }}%)</td>
+          <td id="purchase-discount-percent" colspan="2">({{ '{:.2}'.format(order['discount']*100) }}%)</td>
           <td id="purchase-discount">({{ (subtotal * order['discount'])|format_currency|safe }})</td>
         </tr>
         {% endif %}

--- a/chezbetty/templates/purchase_complete.jinja2
+++ b/chezbetty/templates/purchase_complete.jinja2
@@ -36,6 +36,18 @@
       </tbody>
 
       <tfoot>
+        {% if order['discount'] %}
+        {% set subtotal = transaction.amount / (1-transaction.discount) %}
+        <tr>
+          <td colspan="3"><b>{{ _('Subtotal') }}</b></td>
+          <td id="purchase-subtotal">{{ subtotal|format_currency|safe }}</td>
+        </tr>
+        <tr>
+          <td><b>{{ _('Discounts') }}</b></td>
+          <td id="purchase-discount-percent" colspan="2">({{ '{:.2}'.format(order['discount']) }}%)</td>
+          <td id="purchase-discount">({{ (subtotal * order['discount'])|format_currency|safe }})</td>
+        </tr>
+        {% endif %}
         <tr>
           <td colspan="3">
             <b>{{ _('Total') }}</b>

--- a/chezbetty/templates/user.jinja2
+++ b/chezbetty/templates/user.jinja2
@@ -67,7 +67,7 @@
               </tr>
               <tr>
                 <td><b>{{ _('Discounts') }}</b></td>
-                <td id="purchase-discount-percent" colspan="2">({{ '{:.2}'.format(transaction.discount) }}%)</td>
+                <td id="purchase-discount-percent" colspan="2">({{ '{:.2}'.format(transaction.discount*100) }}%)</td>
                 <td id="purchase-discount">({{ (subtotal * transaction.discount)|format_currency|safe }})</td>
               </tr>
               {% endif %}

--- a/chezbetty/templates/user.jinja2
+++ b/chezbetty/templates/user.jinja2
@@ -59,6 +59,18 @@
             </tbody>
 
             <tfoot>
+              {% if transaction.discount %}
+              {% set subtotal = transaction.amount / (1-transaction.discount) %}
+              <tr>
+                <td colspan="3"><b>{{ _('Subtotal') }}</b></td>
+                <td id="purchase-subtotal">{{ subtotal|format_currency|safe }}</td>
+              </tr>
+              <tr>
+                <td><b>{{ _('Discounts') }}</b></td>
+                <td id="purchase-discount-percent" colspan="2">({{ '{:.2}'.format(transaction.discount) }}%)</td>
+                <td id="purchase-discount">({{ (subtotal * transaction.discount)|format_currency|safe }})</td>
+              </tr>
+              {% endif %}
               <td colspan="3"><b>{{ _('Total') }}</b></td>
               <td class="item-total"><b>{{ transaction.amount|format_currency|safe }}</b></td>
             </tfoot>

--- a/chezbetty/views.py
+++ b/chezbetty/views.py
@@ -285,6 +285,7 @@ def event(request):
         elif event.type == 'purchase':
             # View the purchase success page
             order = {'total': transaction.amount,
+                     'discount': transaction.discount,
                      'items': []}
             for subtrans in transaction.subtransactions:
                 item = {}
@@ -306,6 +307,7 @@ def event(request):
                 {'user': user,
                  'event': event,
                  'order': order,
+                 'transaction': transaction,
                  'account_type': account_type,
                  'pool': pool}, request)
 


### PR DESCRIPTION
This is added in the backend as a `discount` field that represents
the total discount applied to a purchase transaction. The stored
amount in the transaction is the actual amount paid. This has the
least impact on the existing db infrastructure and re-calculating
subtotal when it's needed isn't too bad.

Currently, the $20 threshold and 5% discount are hard-coded. That
should probably not be the case, but it isn't the worst.