### PR TITLE
Made uniqname login case-insensitive

### DIFF
--- a/chezbetty/views.py
+++ b/chezbetty/views.py
@@ -195,7 +195,7 @@ def login_submit(request):
     messages = []
 
     # See if this is a valid login attempt
-    login    = request.params.get('login', '')
+    login    = request.params.get('login', '').lower()
     password = request.params.get('password', '')
     user     = DBSession.query(User).filter(User.uniqname == login).first()
     if user and not user.enabled:


### PR DESCRIPTION
This resolves Issue #308 

Bgreeves == bgreeves == BGREEVES

Converts Uniqname parameter to lowercase before validating it with the database, which, by my shallow investigation, appears to store uniqnames as all lowercase. This may be incorrect. Please let me know if the issue must be solved in a different way.