### PR TITLE
No more wall

### DIFF
--- a/chezbetty/__init__.py
+++ b/chezbetty/__init__.py
@@ -100,8 +100,8 @@ def main(global_config, **settings):
     config.add_route('lang',                '/lang-{code}')
 
     config.add_route('about',               '/about')
-    config.add_route('shame',               '/shame')
-    config.add_route('shame_csv',           '/shame.csv')
+    #config.add_route('shame',               '/shame')
+    #config.add_route('shame_csv',           '/shame.csv')
 
     config.add_route('items',                    '/items')
 

--- a/chezbetty/templates/admin/email_new_top_wall_of_shame.jinja2
+++ b/chezbetty/templates/admin/email_new_top_wall_of_shame.jinja2
@@ -1,7 +1,6 @@
 <p>Hi {{ user.name }},</p>
 
 <p>
-You are now number one on the <a href="https://chezbetty.eecs.umich.edu/shame">Wall of Shame</a>.
 Your Betty balance is {{ user.balance|format_currency|safe }}, more debt than any other user.
 </p>
 
@@ -15,7 +14,7 @@ To view your full transaction history and other information,
 <p>
 As a final note, we strongly encourage users to keep a positive balance instead of accumulating debt.
 We give a 5% discount to any user with $20 or more in their account.
-Please consider paying to a positive balance so that you do not end up right back on the Wall of Shame.
+Please consider paying to a positive balance so that you do not end up right back in debt.
 </p>
 
 <p>Thanks for being a loyal Betty user!</p>

--- a/chezbetty/templates/public/about.jinja2
+++ b/chezbetty/templates/public/about.jinja2
@@ -28,7 +28,7 @@ Shoot us an e-mail at <a href="mailto:chezbetty@umich.edu">chezbetty@umich.edu</
 <h3 class="faq-q">{{ _('How to Use Betty like a Pro') }}</h3>
 <div class="faq-a">
 	<p><strong>{{ _('Keep a positive balance.') }}</strong>
-		{{ _("Tracking down debtors sucks for us and for you. You don't want to end up on the Wall of Shame!") }}
+		{{ _("Tracking down debtors sucks for us and for you. We cannot restock when there is too much user debt.") }}
 	</p>
 	<p><strong>{{ _('Take advantage of the Bank of Betty.') }}</strong>
 		{{ _("Our power users usually deposit $100 once a year or so. Most people deposit $20 to use until that runs out. Remembering cash every time you want to use Betty is no fun.") }}
@@ -76,17 +76,15 @@ Shoot us an e-mail at <a href="mailto:chezbetty@umich.edu">chezbetty@umich.edu</
 <div class="faq-a">
 	<p>{{ _("Yes. Chez Betty allows you to spend beyond your immediate means "
 	"under that assumption that you'll pay Betty back eventually. The idea "
-	"is to let you grab stuff when you need it and keep track of what owe, "
-	"instead of incentivizing folks to steal. There is a "
-	'<a href="/shame">Wall of Shame</a> for persons who owe Betty '
-	"more than $5.")|safe }}</p>
+	"is to let you grab stuff when you need it and keep track of what you owe, "
+	"instead of incentivizing folks to steal.") }}</p>
 </div>
 
 <h3 class="faq-q">{{ _("How does Betty set prices?") }}</h3>
 <div class="faq-a">
 	<p>{{ _("Betty sells things just above wholesale, usually a 15% markup. "
 	"If you're interested in the actual algorithm, check out Betty's source "
-	"code at github.com/um-cseg/chez-betty.") }}</p>
+	"on GitHub.") }}</p>
 	<p>{{ _('Current wholesale and Betty prices are always available on <a href="/items">the items page</a>.')|safe }}</p>
 </div>
 
@@ -95,15 +93,15 @@ Shoot us an e-mail at <a href="mailto:chezbetty@umich.edu">chezbetty@umich.edu</
 	<p>{{ _("If you keep an account balance with $20 or more, Betty will give you a 5% discount on all purchases!") }}</p>
 </div>
 
-<h3 class="faq-q">{{ _("What's the Wall of Shame Tax?") }}</h3>
+<h3 class="faq-q">{{ _("What's the Debtor's Tax?") }}</h3>
 <div class="faq-a">
 	<p>
 	{{
-	_("For people on the Wall of Shame (anyone with less than $5 in their account), Betty charges a progressive tax on all purchases.")
+	_("For anyone with less than $5 in their account, Betty charges a progressive tax on all purchases.")
 	+ ' ' +
 	_("The tax begins at 5% and increases an additional 5% for every additional $5 you are in debt ($10-15 debt is 10%, $15-20 is 15%, and so on).")
 	+ ' ' +
-	_("If you are on the Wall of Shame, the Betty terminal will very clearly show the tax being applied as you check out.")
+	_("If you are more than $5 in debt, the Betty terminal will very clearly show the tax being applied as you check out.")
 	}}
 	</p>
 </div>

--- a/chezbetty/templates/public/index.jinja2
+++ b/chezbetty/templates/public/index.jinja2
@@ -87,28 +87,9 @@ body {
          </div>
         </div>
         {% endif %}
-        
-      </div>
-    </div>
-
-
-    <div class="row">
-      <div class="col-md-12">
-
-        {% for debtor in top_debtors %}
-        <div id="top-debtor-{{ loop.index }}" data-rotate-div-timeout="5000" class="{% if loop.index == 1 %}rotate-divs{% else %}rotate-divs-hidden{% endif %}">
-          <div class="well">
-            <h2>Do you know <strong>{{ debtor.name }}</strong> (<a href="mailto:{{ debtor.uniqname }}@umich.edu?subject=Chez Betty Balance">{{ debtor.uniqname }}</a>)?</h2>
-            <h3><a target="_blank" href="https://mcommunity.umich.edu/#search:{{ debtor.uniqname }}">They</a> are number {{ loop.index }} on the Wall of Shame, with a balance of
-              {{ debtor.balance|format_currency|safe }}.</h3>
-            <h3>If you know {{ debtor.name }}, please encourage them to pay Betty back today.</h3>
-          </div>
-        </div>
-        {% endfor %}
 
       </div>
     </div>
-
   </div>
 
 

--- a/chezbetty/templates/public/index.jinja2
+++ b/chezbetty/templates/public/index.jinja2
@@ -38,7 +38,6 @@ body {
           <a href="/login?redirect={{ request.route_url('user_item_request') }}" class="list-group-item">{{ _('Request an Item') }}</a>
           {% endif %}
           <a href="/about" class="list-group-item">{{ _('About') }}</a>
-          <a href="/shame" class="list-group-item list-group-item-danger">{{ _('Wall of Shame') }}</a>
         </div>
 
       </div>

--- a/chezbetty/templates/terminal/index.jinja2
+++ b/chezbetty/templates/terminal/index.jinja2
@@ -41,6 +41,7 @@ body {
     </div>
 
 
+    {#
     {% if top_debtors|length > 0 %}
     <div class="row" style="margin-top: 20px;">
       <div class="col-md-12">
@@ -66,6 +67,7 @@ body {
       </div>
     </div>
     {% endif %}
+    #}
 
     <div class="row">
       <div class="col-md-12">
@@ -173,6 +175,7 @@ body {
 -->
 
 
+<!--
 {# Secondary splash page #}
 <div id="splash2" class="container" style="display: none;">
   <div style="font-size: 90px; width: 100%;">
@@ -190,6 +193,7 @@ body {
     <a class="btn btn-deftaul btn-huge btn-bordered" style="float:right;" onclick='$("#splash2").hide(); $("#index").show(); $("#footer").show();'>Continue to Betty</a>
   </div>
 </div>
+-->
 
 
 {% endblock %}

--- a/chezbetty/templates/terminal/terminal.jinja2
+++ b/chezbetty/templates/terminal/terminal.jinja2
@@ -220,7 +220,7 @@
                         {% if user.balance >= -5 %}style="display:none;"{% endif %}
                         {% if user.balance < -5 %}class="big-debt"{% endif %}
                         >
-                  <td colspan="2"><b>{{ _('Wall of Shame Fee') }}</b></td>
+                  <td colspan="2"><b>{{ _("Debtor's Fee") }}</b></td>
                   <td id="purchase-fee-percent" colspan="4"><span id="purchase-fee-percent-amount">{{ purchase_fee_percent }}</span>%</td>
                   <td id="purchase-fee">$0.00</td>
                 </tr>

--- a/chezbetty/views.py
+++ b/chezbetty/views.py
@@ -154,17 +154,7 @@ def terminal_force_index(request):
              renderer='templates/public/index.jinja2',
              custom_predicates=(IsTerminalPredicate(False),))
 def index(request):
-
-    try:
-        top_debtors = DBSession.query(User)\
-                         .filter(User.balance < -5)\
-                         .order_by(User.balance)\
-                         .limit(5).all()
-    except NoResultFound:
-        top_debtors = None
-
-    return {'top_debtors': top_debtors,
-            'owed_by_users': User.get_amount_owed()}
+    return {}
 
 # Login routes
 @view_config(route_name='login',

--- a/chezbetty/views_public.py
+++ b/chezbetty/views_public.py
@@ -64,29 +64,29 @@ def items(request):
 
 
 
-def _get_shame_users():
-    users = DBSession.query(User)\
-                     .filter(User.balance < -5)\
-                     .order_by(User.balance).all()
-    for user in users:
-        user.days_on_shame = Transaction.get_days_in_debt_for_user(user)
-    return users
-
-@view_config(route_name='shame', renderer='templates/public/shame.jinja2')
-def shame(request):
-    users = _get_shame_users()
-    return {'users': users}
-
-@view_config(route_name='shame_csv', renderer='csv')
-def shame_csv(request):
-    users = _get_shame_users()
-    header = ['uniqname','balance','name','days_on_shame']
-    rows = [[user.uniqname, user.balance, user.name, user.days_on_shame] for user in users]
-
-    return {
-            'header': header,
-            'rows': rows,
-            }
+#def _get_shame_users():
+#    users = DBSession.query(User)\
+#                     .filter(User.balance < -5)\
+#                     .order_by(User.balance).all()
+#    for user in users:
+#        user.days_on_shame = Transaction.get_days_in_debt_for_user(user)
+#    return users
+#
+#@view_config(route_name='shame', renderer='templates/public/shame.jinja2')
+#def shame(request):
+#    users = _get_shame_users()
+#    return {'users': users}
+#
+#@view_config(route_name='shame_csv', renderer='csv')
+#def shame_csv(request):
+#    users = _get_shame_users()
+#    header = ['uniqname','balance','name','days_on_shame']
+#    rows = [[user.uniqname, user.balance, user.name, user.days_on_shame] for user in users]
+#
+#    return {
+#            'header': header,
+#            'rows': rows,
+#            }
 
 
 @view_config(route_name='paydebt', renderer='templates/public/paydebt.jinja2')


### PR DESCRIPTION
One of the things the administration took umbrage with was the phrase "Wall of Shame" -- didn't feel very leaders & best-y to be publicly shaming debtors like the 16th century was back in style. Plus, there is a circuitous possible FERPA issue that it's just easier to steer clear of. I think this should remove all public-facing WoS references. It keeps the newly-renamed "Debtor's Tax" around. 