### PR TITLE
Updated box and item checks to allow multiple barcodes separated by a…

### DIFF
--- a/chezbetty/models/box.py
+++ b/chezbetty/models/box.py
@@ -1,4 +1,5 @@
 from .model import *
+import re
 
 class Box(Base):
     __tablename__ = 'boxes'
@@ -27,7 +28,25 @@ class Box(Base):
 
     @classmethod
     def from_barcode(cls, barcode):
-        return DBSession.query(cls).filter(cls.barcode == barcode).one()
+        box_list = DBSession.query(cls).filter(cls.barcode.ilike('%{}%'.format(barcode))).all()
+        if(len(box_list) == 1):
+            return box_list[0]
+        else: #list length other than 1 is likely a bad scan, so search for exact match to throw exception if needed
+            return DBSession.query(cls).filter(cls.barcode == barcode).one()
+        #TODO: handle the two cases where len(box_list) != 1 (len is 0, len is > 1)
+
+    @classmethod #search for all delimited barcodes in database; return true if any matches are found
+    def update_exists_barcode(cls, barcode, id):
+        sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
+        result = False
+        for single_barcode in sub:
+            if single_barcode is not "":
+                result = DBSession.query(func.count(cls.id).label('c'))\
+                            .filter(cls.id != id)\
+                            .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
+                if(result):
+                    return result
+        return result
 
     @classmethod
     def from_fuzzy(cls, search_str):

--- a/chezbetty/models/box.py
+++ b/chezbetty/models/box.py
@@ -29,24 +29,11 @@ class Box(Base):
     @classmethod
     def from_barcode(cls, barcode):
         box_list = DBSession.query(cls).filter(cls.barcode.ilike('%{}%'.format(barcode))).all()
-        if(len(box_list) == 1):
+        if len(box_list) == 1:
             return box_list[0]
         else: #list length other than 1 is likely a bad scan, so search for exact match to throw exception if needed
             return DBSession.query(cls).filter(cls.barcode == barcode).one()
         #TODO: handle the two cases where len(box_list) != 1 (len is 0, len is > 1)
-
-    @classmethod #search for all delimited barcodes in database; return true if any matches are found
-    def update_exists_barcode(cls, barcode, id):
-        sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
-        result = False
-        for single_barcode in sub:
-            if single_barcode is not "":
-                result = DBSession.query(func.count(cls.id).label('c'))\
-                            .filter(cls.id != id)\
-                            .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
-                if(result):
-                    return result
-        return result
 
     @classmethod
     def from_fuzzy(cls, search_str):
@@ -82,10 +69,18 @@ class Box(Base):
         return DBSession.query(func.count(cls.id).label('c'))\
                         .filter(cls.name == name).one().c > 0
 
-    @classmethod
-    def exists_barcode(cls, barcode):
-        return DBSession.query(func.count(cls.id).label('c'))\
-                        .filter(cls.barcode == barcode).one().c > 0
+    @classmethod #search for all delimited barcodes in database; return true if any matches are found
+    def exists_barcode(cls, barcode, id=None):
+        sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
+        result = False
+        for single_barcode in sub:
+            if single_barcode != "":
+                result = DBSession.query(func.count(cls.id).label('c'))\
+                            .filter(cls.id != id)\
+                            .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
+                if result:
+                    return result
+        return result
 
     def __str__(self):
         return '<Box ({})>'.format(self.name)

--- a/chezbetty/models/item.py
+++ b/chezbetty/models/item.py
@@ -49,12 +49,13 @@ class Item(Versioned, Base):
     def from_id(cls, id):
         return DBSession.query(cls).filter(cls.id == id).one()
 
-    @classmethod
-    def from_barcode(cls, barcode):
-        return DBSession.query(cls).filter(cls.barcode == barcode).one()
+    # @classmethod
+    # def from_barcode(cls, barcode):
+    #     return DBSession.query(cls).filter(cls.barcode == barcode).one()
 
     @classmethod
-    def from_barcode_sub(cls, barcode):
+    # def from_barcode_sub(cls, barcode):
+    def from_barcode(cls, barcode):
         item_list = DBSession.query(cls).filter(cls.barcode.ilike('%{}%'.format(barcode))).all()
         if(len(item_list) == 1):
             return item_list[0]
@@ -102,20 +103,29 @@ class Item(Versioned, Base):
         return DBSession.query(func.count(cls.id).label('c'))\
                         .filter(cls.name == name).one().c > 0
 
-    @classmethod
-    def exists_barcode(cls, barcode):
-        return DBSession.query(func.count(cls.id).label('c'))\
-                        .filter(cls.barcode == barcode).one().c > 0
-
     @classmethod #search for all delimited barcodes in database; return true if any matches are found
-    def exists_barcode_sub(cls, barcode):
+    def exists_barcode(cls, barcode):
         sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
         result = False
         for single_barcode in sub:
-            result = DBSession.query(func.count(cls.id).label('c'))\
-                        .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
-            if(result):
-                return result
+            if single_barcode is not "":
+                result = DBSession.query(func.count(cls.id).label('c'))\
+                            .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
+                if(result):
+                    return result
+        return result
+
+    @classmethod #check to see if the barcode(s) exist in *other* items (not the current one being updated)
+    def update_exists_barcode(cls, barcode, id):
+        sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
+        result = False
+        for single_barcode in sub:
+            if single_barcode is not "":
+                result = DBSession.query(func.count(cls.id).label('c'))\
+                            .filter(cls.id != id)\
+                            .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
+                if(result):
+                    return result
         return result
 
     @classmethod

--- a/chezbetty/models/item.py
+++ b/chezbetty/models/item.py
@@ -49,15 +49,10 @@ class Item(Versioned, Base):
     def from_id(cls, id):
         return DBSession.query(cls).filter(cls.id == id).one()
 
-    # @classmethod
-    # def from_barcode(cls, barcode):
-    #     return DBSession.query(cls).filter(cls.barcode == barcode).one()
-
     @classmethod
-    # def from_barcode_sub(cls, barcode):
     def from_barcode(cls, barcode):
         item_list = DBSession.query(cls).filter(cls.barcode.ilike('%{}%'.format(barcode))).all()
-        if(len(item_list) == 1):
+        if len(item_list) == 1:
             return item_list[0]
         else: #list length other than 1 is likely a bad scan, so search for exact match to throw exception if needed
             return DBSession.query(cls).filter(cls.barcode == barcode).one()
@@ -103,20 +98,8 @@ class Item(Versioned, Base):
         return DBSession.query(func.count(cls.id).label('c'))\
                         .filter(cls.name == name).one().c > 0
 
-    @classmethod #search for all delimited barcodes in database; return true if any matches are found
-    def exists_barcode(cls, barcode):
-        sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
-        result = False
-        for single_barcode in sub:
-            if single_barcode is not "":
-                result = DBSession.query(func.count(cls.id).label('c'))\
-                            .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
-                if(result):
-                    return result
-        return result
-
     @classmethod #check to see if the barcode(s) exist in *other* items (not the current one being updated)
-    def update_exists_barcode(cls, barcode, id):
+    def exists_barcode(cls, barcode, id=None):
         sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
         result = False
         for single_barcode in sub:
@@ -124,7 +107,7 @@ class Item(Versioned, Base):
                 result = DBSession.query(func.count(cls.id).label('c'))\
                             .filter(cls.id != id)\
                             .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0
-                if(result):
+                if result:
                     return result
         return result
 

--- a/chezbetty/models/item.py
+++ b/chezbetty/models/item.py
@@ -103,7 +103,7 @@ class Item(Versioned, Base):
         sub = re.compile(r'[^\d;]+').sub('', barcode).split(';') #remove any characters that aren't digits or delimiters
         result = False
         for single_barcode in sub:
-            if single_barcode is not "":
+            if single_barcode != "":
                 result = DBSession.query(func.count(cls.id).label('c'))\
                             .filter(cls.id != id)\
                             .filter(cls.barcode.ilike('%{}%'.format(single_barcode))).one().c > 0

--- a/chezbetty/models/user.py
+++ b/chezbetty/models/user.py
@@ -297,6 +297,20 @@ class User(account.Account):
                         .all()
         return utility.timeseries_cumulative(rows)
 
+    def purchase_threshold_check(self, limit=None):
+        count = 0
+        for e in self.events:
+            if e.type == 'purchase':
+                count += 1
+        return count <= limit
+
+    def deposit_threshold_check(self, limit=None):
+        count = 0
+        for e in self.events:
+            if e.type == 'deposit':
+                count += 1
+        return count <= limit
+
     def iterate_recent_items(self, limit=None, allow_duplicates=False, pictures_only=True):
         cap_search = 20
         items = set()

--- a/chezbetty/templates/admin/restock_row.jinja2
+++ b/chezbetty/templates/admin/restock_row.jinja2
@@ -8,7 +8,7 @@
   <td class="name">
     {{ item|make_link|safe }}
 
-    <div class="row">
+    <div class="row" style="word-wrap: break-word;">
       <div class="col-sm-7">Barcode</div>
       <div class="col-sm-5">{{ item.barcode }}</div>
     </div>
@@ -32,7 +32,7 @@
     </div>
     {% endfor %}
 
-    <div class="row">
+    <div class="row" style="word-wrap: break-word;">
       <div class="col-sm-7">Barcode</div>
       <div class="col-sm-5">{{ box.barcode }}</div>
     </div>

--- a/chezbetty/templates/terminal/terminal.jinja2
+++ b/chezbetty/templates/terminal/terminal.jinja2
@@ -23,12 +23,28 @@
     <p style="font-size:125%;">{{ _('Please try to pay Betty back soon!') }}</p>
   </div>
 </div>
+<div id="user-zero-purchases" class="alert user-zero-purchase-popup" role="alert" {% if user.purchase_threshold_check(limit=3) or user.deposit_threshold_check(limit=0) %}{% else %}style="display:none;"{% endif %}>
+  <div class="container">
+    <h2 style="font-size:125%;">{{ _('Hi %(name)s,')|format(name=user.name) }}</h2>
+    <p style="font-size:150%;"><b>{{ _("Welcome to Chez Betty!") }}</b></p>
+  </div>
+</div>
 
 <div id="dialog-confirm" class="dialog-test alert alert-danger user-alert-balance" role="alert" style="display:none;">
   <center><p style="font-size:200%;"><b>{{ _("Your Betty balance is currently") }}</b></p></center>
   <center><p style="font-size:500%;"><b>{{ _("%(debt)s")|format(debt='<span class="current-formatted-balance">'~user.balance|format_currency~'</span>')|safe }}</b></p></center>
   <center><p style="font-size:200%;"><b>{{ _("Which incurs a penalty fee of ") }}</b><b style="color:red;">{{ _("%(debt)s&#37")|format(debt='<span class="current-formatted-balance">'~purchase_fee_percent~'</span>')|safe }}</b></p></center>
   <center><p style="font-size:200%;"><b>Remember that Betty is run and financed entirely by student volunteers, and is NOT linked to your UM student account for payments. Please help support Betty operations by paying back your debt either online via credit card or using the bill machine next to the terminal. Thank you for your continued business.</b></p></center>
+</div>
+
+<div id="dialog-new-user" class="dialog-test alert user-zero-purchase-popup" role="alert" style="display:none;">
+  <center><p style="font-size:200%;"><b>Hello new user! Please read the below instructions before using Betty:</b></p></center>
+  <p style="font-size:150%;"><b>1. Load money onto your account (your current balance is {{ _("%(debt)s")|format(debt='<span class="current-formatted-balance">'~user.balance|format_currency~'</span>')|safe }}).</b></p>
+  <p style="font-size:150%;"><b>2. Scan items you wish to purchase.</b></p>
+  <p style="font-size:150%;"><b>3. Click Pay and Logout. You're done!</b></p>
+  <br>
+  <center><p style="font-size:200%;"><b>Remember: Betty is NOT linked to your UM student account or Blue Bucks for payments.</b></p></center>
+  <center><p style="font-size:200%;"><b>Fund your account using the bill acceptor for cash or using the online portal for credit cards.</b></p></center>
 </div>
 
 
@@ -305,6 +321,27 @@
         draggable: false,
         buttons: {
           "I Have Read and Understand": function() {
+            $( this ).dialog( "close" );
+          }
+        }
+      });
+    } );
+  }
+  </script>
+
+<script>
+  if(document.getElementById("user-zero-purchases").style.display != "none") {
+    $( function() {
+      var wWidth = $(window).width();
+      var dWidth = wWidth * 0.75;
+      $( "#dialog-new-user" ).dialog({
+        resizable: false,
+        height: "auto",
+        width: dWidth,
+        modal: true,
+        draggable: false,
+        buttons: {
+          "Continue to Betty": function() {
             $( this ).dialog( "close" );
           }
         }

--- a/chezbetty/views_admin.py
+++ b/chezbetty/views_admin.py
@@ -1838,7 +1838,7 @@ def admin_item_edit_submit(request):
                     val = round(Decimal(request.POST[key]), 4)
                 elif field == 'barcode':
                     val = request.POST[key].strip() or None
-                    if item.update_exists_barcode(val, item.id):
+                    if item.exists_barcode(val, item.id):
                         request.session.flash('Error updating item. DEFINITELY conflicting barcodes.', 'error')
                         return HTTPFound(location=request.route_url('admin_item_edit', item_id=int(request.POST['item-id'])))
                 elif field == 'sales_tax':
@@ -2258,7 +2258,7 @@ def admin_box_edit_submit(request):
     try:
         box = Box.from_id(int(request.POST['box-id']))
 
-        if not box.update_exists_barcode(request.POST['box-barcode'], box.id):
+        if not box.exists_barcode(request.POST['box-barcode'], box.id):
             for key in request.POST:
                 fields = key.split('-')
                 if fields[1] == 'item' and fields[2] == 'id':

--- a/chezbetty/views_admin.py
+++ b/chezbetty/views_admin.py
@@ -1838,6 +1838,9 @@ def admin_item_edit_submit(request):
                     val = round(Decimal(request.POST[key]), 4)
                 elif field == 'barcode':
                     val = request.POST[key].strip() or None
+                    if item.update_exists_barcode(val, item.id):
+                        request.session.flash('Error updating item. DEFINITELY conflicting barcodes.', 'error')
+                        return HTTPFound(location=request.route_url('admin_item_edit', item_id=int(request.POST['item-id'])))
                 elif field == 'sales_tax':
                     val = request.POST[key] == 'on'
                 elif field == 'bottle_dep':
@@ -2255,73 +2258,77 @@ def admin_box_edit_submit(request):
     try:
         box = Box.from_id(int(request.POST['box-id']))
 
-        for key in request.POST:
-            fields = key.split('-')
-            if fields[1] == 'item' and fields[2] == 'id':
-                # Handle the sub item quantities
-                item_id  = int(request.POST['box-item-id-'+fields[3]])
-                quantity = request.POST['box-item-quantity-'+fields[3]].strip()
-                percentage = request.POST['box-item-percentage-'+fields[3]].strip()
+        if not box.update_exists_barcode(request.POST['box-barcode'], box.id):
+            for key in request.POST:
+                fields = key.split('-')
+                if fields[1] == 'item' and fields[2] == 'id':
+                    # Handle the sub item quantities
+                    item_id  = int(request.POST['box-item-id-'+fields[3]])
+                    quantity = request.POST['box-item-quantity-'+fields[3]].strip()
+                    percentage = request.POST['box-item-percentage-'+fields[3]].strip()
 
-                for boxitem in box.items:
-                    # Update the BoxItem record.
-                    # If the item quantity is zero or blank, set the record to
-                    # disabled and do not update the quantity.
-                    if boxitem.item_id == item_id and boxitem.enabled:
-                        if quantity == '' or int(quantity) == 0:
-                            boxitem.enabled = False
-                        else:
-                            boxitem.quantity = int(quantity)
-                            boxitem.percentage = round(Decimal(percentage), 2)
-                        break
+                    for boxitem in box.items:
+                        # Update the BoxItem record.
+                        # If the item quantity is zero or blank, set the record to
+                        # disabled and do not update the quantity.
+                        if boxitem.item_id == item_id and boxitem.enabled:
+                            if quantity == '' or int(quantity) == 0:
+                                boxitem.enabled = False
+                            else:
+                                boxitem.quantity = int(quantity)
+                                boxitem.percentage = round(Decimal(percentage), 2)
+                            break
+                    else:
+                        if quantity != '':
+                            # Add a new vendor to the item
+                            item = Item.from_id(item_id)
+                            box_item = BoxItem(box, item, quantity, round(Decimal(percentage), 2))
+                            DBSession.add(box_item)
+
+                elif fields[1] == 'vendor' and fields[2] == 'id':
+                    # Handle the vendor item numbers
+                    vendor_id = int(request.POST['box-vendor-id-'+fields[3]])
+                    item_num  = request.POST['box-vendor-item_num-'+fields[3]].strip()
+
+                    for vendorbox in box.vendors:
+                        # Update the VendorItem record.
+                        # If the item num is blank, set the record to disabled
+                        # and do not update the item number.
+                        if vendorbox.vendor_id == vendor_id and vendorbox.enabled:
+                            if item_num == '':
+                                vendorbox.enabled = False
+                            else:
+                                vendorbox.item_number = item_num
+                            break
+                    else:
+                        if item_num != '':
+                            # Add a new vendor to the item
+                            vendor = Vendor.from_id(vendor_id)
+                            box_vendor = BoxVendor(vendor, box, item_num)
+                            DBSession.add(box_vendor)
+
                 else:
-                    if quantity != '':
-                        # Add a new vendor to the item
-                        item = Item.from_id(item_id)
-                        box_item = BoxItem(box, item, quantity, round(Decimal(percentage), 2))
-                        DBSession.add(box_item)
+                    # Update the base item
+                    field = fields[1]
+                    if field == 'wholesale':
+                        val = round(Decimal(request.POST[key]), 2)
+                    elif field == 'quantity':
+                        val = int(request.POST[key])
+                    elif field == 'sales_tax':
+                        val = request.POST[key] == 'on'
+                    elif field == 'bottle_dep':
+                        val = request.POST[key] == 'on'
+                    else:
+                        val = request.POST[key].strip()
 
-            elif fields[1] == 'vendor' and fields[2] == 'id':
-                # Handle the vendor item numbers
-                vendor_id = int(request.POST['box-vendor-id-'+fields[3]])
-                item_num  = request.POST['box-vendor-item_num-'+fields[3]].strip()
+                    setattr(box, field, val)
 
-                for vendorbox in box.vendors:
-                    # Update the VendorItem record.
-                    # If the item num is blank, set the record to disabled
-                    # and do not update the item number.
-                    if vendorbox.vendor_id == vendor_id and vendorbox.enabled:
-                        if item_num == '':
-                            vendorbox.enabled = False
-                        else:
-                            vendorbox.item_number = item_num
-                        break
-                else:
-                    if item_num != '':
-                        # Add a new vendor to the item
-                        vendor = Vendor.from_id(vendor_id)
-                        box_vendor = BoxVendor(vendor, box, item_num)
-                        DBSession.add(box_vendor)
-
-            else:
-                # Update the base item
-                field = fields[1]
-                if field == 'wholesale':
-                    val = round(Decimal(request.POST[key]), 2)
-                elif field == 'quantity':
-                    val = int(request.POST[key])
-                elif field == 'sales_tax':
-                    val = request.POST[key] == 'on'
-                elif field == 'bottle_dep':
-                    val = request.POST[key] == 'on'
-                else:
-                    val = request.POST[key].strip()
-
-                setattr(box, field, val)
-
-        DBSession.flush()
-        request.session.flash('Box updated successfully.', 'success')
-        return HTTPFound(location=request.route_url('admin_box_edit', box_id=int(request.POST['box-id'])))
+            DBSession.flush()
+            request.session.flash('Box updated successfully.', 'success')
+            return HTTPFound(location=request.route_url('admin_box_edit', box_id=int(request.POST['box-id'])))
+        else:
+            request.session.flash('Error updating box. Probably conflicting barcodes.', 'error')
+            return HTTPFound(location=request.route_url('admin_box_edit', box_id=int(request.POST['box-id'])))
 
     except NoResultFound:
         request.session.flash('Error when updating box.', 'error')


### PR DESCRIPTION
Updated box and item checks to allow multiple barcodes separated by a semicolon as a delimiter. Currently using a single string as storage; "better" methods (allowing multiple barcodes in the database) would require heavy database updates.

This update should ensure that box and item barcode(s) are unique. If implemented, the database should be updated to merge duplicate boxes and items (probably a manual procedure).